### PR TITLE
Add Deno server signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ ENV PORT=8080
 
 RUN deno cache --unstable-kv --no-check main.ts
 
-STOPSIGNAL SIGKILL
-
 ENTRYPOINT [ \
 	"deno", "run",\
 	# Allow access to the environment variables

--- a/lib/cli/server.ts
+++ b/lib/cli/server.ts
@@ -33,7 +33,8 @@ export function runServer(args: unknown): Promise<void> {
     ac.abort(signal);
   };
   (["SIGHUP", "SIGINT", "SIGTERM"] as Deno.Signal[]).forEach((signal) =>
-    Deno.addSignalListener(signal, () => handler(signal)));
+    Deno.addSignalListener(signal, () => handler(signal))
+  );
 
   console.log();
   const server = Deno.serve(

--- a/lib/cli/server.ts
+++ b/lib/cli/server.ts
@@ -14,7 +14,7 @@ const serverArgs = z.object({
  * @param args.port the port to listen on (default: the PORT environment variable)
  * @param args.host the hostname to listen on (default: 0.0.0.0)
  */
-export function runServer(args: unknown) {
+export function runServer(args: unknown): Promise<void> {
   console.log(`Running ${metadata.name} v${metadata.version}`);
   console.log();
 
@@ -27,9 +27,18 @@ export function runServer(args: unknown) {
   console.log("Paths:");
   logPaths();
 
+  const ac = new AbortController();
+  const handler = (signal: Deno.Signal) => {
+    console.log(`Caught ${signal}. Closing server...`);
+    ac.abort(signal);
+  };
+  (["SIGHUP", "SIGINT", "SIGTERM"] as Deno.Signal[]).forEach((signal) =>
+    Deno.addSignalListener(signal, () => handler(signal)));
+
   console.log();
-  Deno.serve(
-    { port: parsedArgs.port, hostname: parsedArgs.host },
+  const server = Deno.serve(
+    { port: parsedArgs.port, hostname: parsedArgs.host, signal: ac.signal },
     httpApp.fetch,
   );
+  return server.finished;
 }


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

This pull request adds signal handling for the Deno http server.

### Details <!-- Describe the content of the pull request -->

The following signals are properly caught:

- `SIGHUP`
- `SIGINT`
- `SIGTERM`

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

Tested natively on Archlinux and in docker compose rootful.

### Related links <!-- Related resources, issues and pull requests -->

_none_

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
