### PR TITLE
Add OIDC callback route to http app

### DIFF
--- a/lib/http/mod.ts
+++ b/lib/http/mod.ts
@@ -15,6 +15,7 @@ import { svgRoutes } from "$http/routes/svg.ts";
 import { uiRoutes } from "$http/routes/ui.tsx";
 import { apiRoutes } from "$http/routes/api.ts";
 import { lookupRoutes } from "$http/routes/lookup.ts";
+import { withUser } from "$http/middleware/oidc.ts";
 
 export * from "$http/lookup-url.ts";
 export * from "$http/barcode-svg.ts";
@@ -48,3 +49,8 @@ httpApp.route("/api", apiRoutes);
 httpApp.route("/svg", svgRoutes);
 httpApp.route("/", lookupRoutes);
 httpApp.route("/", uiRoutes);
+httpApp.get(
+  "/oidc/callback",
+  withUser,
+  (c) => c.text("OIDC not configured", 404),
+);


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

This PR fixes the OIDC integration not properly handling the OIDC redirect URI.
It adds the route `/oidc/callback` the the Hono HTTP app that calls the `withUser` middleware.

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

- Fixes # .

### CLA

- [ ] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.

<!-- branch-stack -->

- `main`
  - \#9 :point\_left:
